### PR TITLE
Mirror of square whorlwind#27

### DIFF
--- a/whorlwind/src/main/java/com/squareup/whorlwind/FingerprintAuthOnSubscribe.java
+++ b/whorlwind/src/main/java/com/squareup/whorlwind/FingerprintAuthOnSubscribe.java
@@ -145,6 +145,9 @@ import okio.ByteString;
                     ReadResult.create(ReadState.READY, -1, null, ByteString.of(decrypted)));
                 emitter.onComplete();
               } catch (IllegalBlockSizeException | BadPaddingException e) {
+                if (e instanceof IllegalBlockSizeException) {
+                  whorlwind.removeKey();
+                }
                 Log.i(Whorlwind.TAG, "Failed to decrypt.", e);
                 emitter.onError(e);
               }

--- a/whorlwind/src/main/java/com/squareup/whorlwind/RealWhorlwind.java
+++ b/whorlwind/src/main/java/com/squareup/whorlwind/RealWhorlwind.java
@@ -180,7 +180,6 @@ final class RealWhorlwind extends Whorlwind {
 
   void removeKey() {
     try {
-      keyStore.load(null);
       keyStore.deleteEntry(keyAlias);
     } catch (Exception e) {
       Log.d(TAG, "Remove key failed", e);

--- a/whorlwind/src/main/java/com/squareup/whorlwind/RealWhorlwind.java
+++ b/whorlwind/src/main/java/com/squareup/whorlwind/RealWhorlwind.java
@@ -177,4 +177,13 @@ final class RealWhorlwind extends Whorlwind {
   PrivateKey getPrivateKey() throws GeneralSecurityException {
     return (PrivateKey) keyStore.getKey(keyAlias, null);
   }
+
+  public void removeKey() {
+    try {
+      keyStore.load(null);
+      keyStore.deleteEntry(keyAlias);
+    } catch (Exception e) {
+      Log.d(TAG, "Remove key failed", e);
+    }
+  }
 }

--- a/whorlwind/src/main/java/com/squareup/whorlwind/RealWhorlwind.java
+++ b/whorlwind/src/main/java/com/squareup/whorlwind/RealWhorlwind.java
@@ -178,7 +178,7 @@ final class RealWhorlwind extends Whorlwind {
     return (PrivateKey) keyStore.getKey(keyAlias, null);
   }
 
-  public void removeKey() {
+  void removeKey() {
     try {
       keyStore.load(null);
       keyStore.deleteEntry(keyAlias);


### PR DESCRIPTION
Mirror of square whorlwind#27
As raised in issue #26 , on android 8.0 an IllegalBlockSizeException is thrown when a new fingerprint is added. By removing the keys when this exception is thrown the user will not be stuck in a state where the fingerprint cannot be reconfigured/app crashes. 
